### PR TITLE
Small things

### DIFF
--- a/compile.zig
+++ b/compile.zig
@@ -15,7 +15,7 @@ pub fn build(builder: *std.build.Builder) !void {
         "example-option",
         "test passing an option through build.zig",
     );
-    std.log.info("example-option: {}", .{example_option});
+    std.log.info("example-option: {any}", .{example_option});
 }
 
 const ExampleStep = struct {

--- a/fetch.zig
+++ b/fetch.zig
@@ -50,7 +50,7 @@ pub fn fetchAndBuild(
     builder.getInstallStep().dependOn(&fetch_and_build.step);
 }
 
-const FetchAndBuild = struct {
+pub const FetchAndBuild = struct {
     builder: *std.build.Builder,
     step: std.build.Step,
     deps: []const Dependency,
@@ -59,7 +59,7 @@ const FetchAndBuild = struct {
     run_zig_build: bool,
     fetch_cache_path: []const u8,
 
-    fn init(
+    pub fn init(
         builder: *std.build.Builder,
         deps_dir: []const u8,
         deps: []const Dependency,


### PR DESCRIPTION
- small syntax error fix in compile.zig (Zig 0.10.0)
- make FetchAndBuild.init public; this allows usage not tied to builder install step: [link to example](https://github.com/hazeycode/hazeytek/blob/e836e99b544002ab64c8c80c047ae8e3e3f9ea54/libs/platform/libs/zopengl/build.zig#L21)